### PR TITLE
Added support for specifying training and matching indices

### DIFF
--- a/models.py
+++ b/models.py
@@ -114,6 +114,8 @@ class Atlas:
         Args:
             col (np.ndarray): NxC color array (C num channels)
             pos (np.ndarray): Nx3 position array
+            train_indices (np.ndarray or list): indices of ims to use for training
+            match_indices (np.ndarray or list): indices of ims to use for initial spatial matching in initialize atlas
                 
         Returns:
             atlas (dict): Initialized atlas
@@ -274,6 +276,8 @@ class Atlas:
             positions (np.ndarray): Nx3 position array
             colors (np.ndarray): NxC color array
             bodypart (str): Worm's body part (head or tail)
+            train_indices (np.ndarray or list): indices of ims to use for training
+            match_indices (np.ndarray or list): indices of ims to use for initial spatial matching in initialize atlas
                 
         Returns:
             atlas (dict): Trained atlas


### PR DESCRIPTION
I added additional parameters to the train_atlas function in models.py to specify indices for training and matching. Train_indices specifies the indices of the list of ims to be used for training while match_indices specifics the indices of the list of ims to be used for the initial spatial alignment. All ims are aligned to the common atlas space, but only the ims specified in train_indices are used to update the means and covariances of the atlas. If no training or match indices are specified, functionality is the same as before using all ims for training and matching. There are slight changes to the train_atlas function, the sort_mu function, and the initialize_atlas function but no changes to other functions.

I tested this functionality using both my own code for training the atlas used in this [bioRxiv pre-print ](https://www.biorxiv.org/content/10.1101/2024.04.28.591397v1.article-metrics) as well as using the original demo.py.

In addition, I fixed a bug where the estimate_sigma function was not properly masking inputs to the covariance calculation, causing any neurons that were not represented in all datasets to have NaN covariance matrices. The fix was just a simple addition to the np.ma.masked_array function to specify how to set the mask. 